### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0](https://github.com/bearcove/fopro/releases/tag/v1.0.0) - 2024-10-12
+
+### Other
+
+- Add release-plz + test
+- Add README
+- In-memory cache layer
+- add in-memory
+- Only cache 200 actually
+- don't panic
+- Only cache 200
+- Format better
+- Show status/method
+- Don't cache everything
+- Different cache key strat
+- Add on-disk caching
+- debug++
+- don't print broken pipe errors
+- Proxy request bodies (makes POST work, which makes git clones over HTTPS work)
+- Actually forward to upstream
+- Proxy reqwests upstream, just missing roots..
+- Service proxied requests (WIP)
+- Negotiate TLS
+- perform upgrade
+- Dump incoming request
+- Initial setup
+- Initial release


### PR DESCRIPTION
## 🤖 New release
* `fopro`: 1.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0](https://github.com/bearcove/fopro/releases/tag/v1.0.0) - 2024-10-12

### Other

- Add release-plz + test
- Add README
- In-memory cache layer
- add in-memory
- Only cache 200 actually
- don't panic
- Only cache 200
- Format better
- Show status/method
- Don't cache everything
- Different cache key strat
- Add on-disk caching
- debug++
- don't print broken pipe errors
- Proxy request bodies (makes POST work, which makes git clones over HTTPS work)
- Actually forward to upstream
- Proxy reqwests upstream, just missing roots..
- Service proxied requests (WIP)
- Negotiate TLS
- perform upgrade
- Dump incoming request
- Initial setup
- Initial release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).