### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/bearcove/fopro/compare/v1.0.1...v1.0.2) - 2024-10-13
+
+### Added
+
+- Dump CA cert to /tmp/fopro-ca.crt
+
 ## [1.0.1](https://github.com/bearcove/fopro/compare/v1.0.0...v1.0.1) - 2024-10-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fopro"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "byteorder",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fopro"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Experimental caching HTTP forward proxy (memory+disk)"


### PR DESCRIPTION
## 🤖 New release
* `fopro`: 1.0.1 -> 1.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.2](https://github.com/bearcove/fopro/compare/v1.0.1...v1.0.2) - 2024-10-13

### Added

- Dump CA cert to /tmp/fopro-ca.crt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).