### PR TITLE
chore: release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5](https://github.com/bearcove/fopro/compare/v1.0.4...v1.0.5) - 2024-10-13
+
+### Other
+
+- use system temp dir, which hopefully fixes things on windows
+
 ## [1.0.4](https://github.com/bearcove/fopro/compare/v1.0.3...v1.0.4) - 2024-10-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fopro"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "byteorder",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fopro"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Experimental caching HTTP forward proxy (memory+disk)"


### PR DESCRIPTION
## 🤖 New release
* `fopro`: 1.0.4 -> 1.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.5](https://github.com/bearcove/fopro/compare/v1.0.4...v1.0.5) - 2024-10-13

### Other

- use system temp dir, which hopefully fixes things on windows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).