### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/bearcove/fopro/compare/v2.0.0...v2.0.1) - 2024-10-13
+
+### Fixed
+
+- Version cache
+
+### Other
+
+- Build with debug symbols (some)
+- Don't constantly regenerate certs
+- version the cache
+
 ## [2.0.0](https://github.com/bearcove/fopro/compare/v1.0.5...v2.0.0) - 2024-10-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fopro"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "argh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fopro"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Experimental caching HTTP forward proxy (memory+disk)"


### PR DESCRIPTION
## 🤖 New release
* `fopro`: 2.0.0 -> 2.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.1](https://github.com/bearcove/fopro/compare/v2.0.0...v2.0.1) - 2024-10-13

### Fixed

- Version cache

### Other

- Build with debug symbols (some)
- Don't constantly regenerate certs
- version the cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).