### PR TITLE
chore: release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2](https://github.com/bearcove/fopro/compare/v2.0.1...v2.0.2) - 2024-10-13
+
+### Other
+
+- take _some_ headers into account when computing the cache key
+
 ## [2.0.1](https://github.com/bearcove/fopro/compare/v2.0.0...v2.0.1) - 2024-10-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fopro"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "argh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fopro"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Experimental caching HTTP forward proxy (memory+disk)"


### PR DESCRIPTION
## 🤖 New release
* `fopro`: 2.0.1 -> 2.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.2](https://github.com/bearcove/fopro/compare/v2.0.1...v2.0.2) - 2024-10-13

### Other

- take _some_ headers into account when computing the cache key
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).